### PR TITLE
Solved CSOC Page Indentation ( Fixes #51)

### DIFF
--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -8,12 +8,8 @@ layout: default
   </div>
 </div>
 
-<div class="row">
-  <div class="col-lg-8 col-lg-offset-2">
-    <div class="wrapper wrapper-content animated fadeInRight">
-      {{ content }}
-    </div>
-  </div>
+<div class="wrapper wrapper-content animated fadeInRight">
+  {{ content }}
 </div>
 
 <style>

--- a/resources/potw.html
+++ b/resources/potw.html
@@ -10,6 +10,8 @@ permalink: /resources/potw/
     </div>
 </div>
 
+<div class="row">
+<div class="col-lg-8 col-lg-offset-2">
 <div class="panel-group" id="accordion">
     {% for topic in site.data.potw %}
     {%- assign title = topic.name -%}
@@ -35,4 +37,6 @@ permalink: /resources/potw/
         </div>
     </div>
     {% endfor %}
+</div>
+</div>
 </div>


### PR DESCRIPTION
Fixes #51 

Whole content on the CSOC Page is indented towards the right. I've tried to solve it.

<br>
Originally, the page looked like:

![Screenshot from 2019-06-29 15-50-00](https://user-images.githubusercontent.com/39548570/60383237-0581c380-9a8c-11e9-9128-f8d727a30191.png)
<br>
![Screenshot from 2019-06-29 15-50-06](https://user-images.githubusercontent.com/39548570/60383239-0c103b00-9a8c-11e9-8069-e8e34b173dee.png)

<br>
After the changes, the page is indented correctly:

![Screenshot from 2019-06-29 15-50-13](https://user-images.githubusercontent.com/39548570/60383245-16323980-9a8c-11e9-8a52-ce4744c072c4.png)
<br>
![Screenshot from 2019-06-29 15-50-17](https://user-images.githubusercontent.com/39548570/60383246-18949380-9a8c-11e9-8078-29aca4056f28.png)