### PR TITLE
Added missing POTW Document Link (Fixes #54)

### DIFF
--- a/_data/potw.yml
+++ b/_data/potw.yml
@@ -1,5 +1,12 @@
 # sections of potw
 
+- name: Moving from C to C++
+  tutorial:
+    - title: Google Drive Link
+      links:
+        - label: C to Cpp
+          url: https://docs.google.com/document/d/1SSPtJEyM6Ze4DePE-EBhIHYqb2kumUvpYXehmzKK2xQ/
+
 - name: Standard Template Library
   tutorial:
     - title: Standard Template Library - Part 1

--- a/_data/potw.yml
+++ b/_data/potw.yml
@@ -4,7 +4,7 @@
   tutorial:
     - title: Google Drive Link
       links:
-        - label: C to Cpp
+        - label: COPS
           url: https://docs.google.com/document/d/1SSPtJEyM6Ze4DePE-EBhIHYqb2kumUvpYXehmzKK2xQ/
 
 - name: Standard Template Library


### PR DESCRIPTION
Fixes #54 

Just added the missing link for the <a href="https://docs.google.com/document/d/1J2c5zkhvZQ8U2S5PNxZoTQce0MO2JCdPOrnfViZ2Lv8/">POTW</a> document titled <a href="https://docs.google.com/document/u/1/d/1SSPtJEyM6Ze4DePE-EBhIHYqb2kumUvpYXehmzKK2xQ/">"Moving from C to C++"</a>