### PR TITLE
navbar: Fixes the incorrect color rendered at focus in dark mode.

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -2634,7 +2634,7 @@ body {
         }
         &:focus {
           background: inherit;
-          color: var(--white);
+          color: white;
         }
       }
       .active > a:focus {


### PR DESCRIPTION
Fixes #124

Before:
![Screenshot (57)](https://user-images.githubusercontent.com/76519771/141779951-2107a9c8-05bf-4c85-b1f0-55e4c1130b09.png)

After:
![Screenshot (58)](https://user-images.githubusercontent.com/76519771/141780009-0c005746-a92c-44f8-9ef0-73c851b56459.png)


